### PR TITLE
#17 - Added missing part of `defaults` test from ES6 to ES5 version

### DIFF
--- a/tests/defaults/defaults.es5
+++ b/tests/defaults/defaults.es5
@@ -6,5 +6,6 @@ function fn(arg, other) {
 
 test(function() {
   fn();
+  fn(2);
   fn(2, 4);
 });


### PR DESCRIPTION
According to issue #17, I added missing function call to `defaults` test.
