### PR TITLE
Added spreading arrays in function calls. 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Kevin Decker
+Copyright (c) 2015 Kevin Decker, 2016 Matthias v/d Meent
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "homepage": "https://github.com/kpdecker/six-speed",
   "authors": [
-    "kpdecker <kpdecker@gmail.com>"
+    "kpdecker <kpdecker@gmail.com>",
+    "mmeent <boekewurm@gmail.com>"
   ],
   "license": "MIT",
   "ignore": [

--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
   },
   "author": "Kevin Decker <kpdecker@gmail.com>",
   "license": "MIT",
+  "contributors": [
+    {
+      "name": "Matthias v/d Meent",
+      "email": "boekewurm@gmail.com"
+    }
+  ],
   "dependencies": {
     "applescript": "^1.0.0",
     "async": "^1.2.1",

--- a/tests/spread-function-call/spread-function-call.es5
+++ b/tests/spread-function-call/spread-function-call.es5
@@ -42,6 +42,6 @@ assertEqual(fn(0, __(list), 4), 2);
 test(function() {
   fn();
   fn(__(list));
-  fn(3, 2, __(list));
+  fn(3, [2, 1, 0], __(list));
   fn(0, __(list), 4);
 });

--- a/tests/spread-function-call/spread-function-call.es5
+++ b/tests/spread-function-call/spread-function-call.es5
@@ -1,0 +1,47 @@
+var list = [1, 2, 3];
+
+Array.prototype.expand = false;
+
+function __(list) {
+  list.expand = true;
+  return list;
+}
+
+// wrap the function to be called, so that the arguments are parsed first.
+function wrap(func) {
+  return function() {
+    var args = [];
+    for (var i = 0; i < arguments.length; i++) {
+      var arg = arguments[i];
+      if ((arg instanceof Array) && arg.expand === true) {
+        Array.prototype.push.apply(args, arg);
+        arg.expand = false;
+      } else {
+        args.push(arg);
+      }
+    }
+    return func.apply(this, args);
+  }
+}
+
+var fn = wrap(function(a, b, c, d, e) {
+  return c;
+});
+
+assertEqual(fn(), undefined);
+// don't fail with no arguments.
+assertEqual(fn(list), undefined);
+// make sure that lists are not auto-spread.
+assertEqual(fn(__(list)), 3);
+// equivalent to fn(1, 2, 3);
+assertEqual(fn(3, [2, 1, 0], __(list)), 1);
+// equivalent to fn(3, [2, 1, 0], 1, 2, 3); Makes sure that list arguments are not spread by default.
+assertEqual(fn(0, __(list), 4), 2);
+// equivalent to fn(0, 1, 2, 3, 4);
+
+test(function() {
+  fn();
+  fn(__(list));
+  fn(3, 2, __(list));
+  fn(0, __(list), 4);
+});

--- a/tests/spread-function-call/spread-function-call.es6
+++ b/tests/spread-function-call/spread-function-call.es6
@@ -1,0 +1,23 @@
+var list = [1, 2, 3];
+
+function fn(a, b, c, d, e) {
+  return c;
+}
+
+assertEqual(fn(), undefined);
+// don't fail with no arguments.
+assertEqual(fn(list), undefined);
+// make sure that lists are not auto-spread.
+assertEqual(fn(...list), 3);
+// equivalent to fn(1, 2, 3);
+assertEqual(fn(3, [2, 1, 0], ...list), 1);
+// equivalent to fn(3, [2, 1, 0], 1, 2, 3); Makes sure that list arguments are not spread by default.
+assertEqual(fn(0, ...list, 4), 2);
+// equivalent to fn(0, 1, 2, 3, 4);
+
+test(function() {
+  fn();
+  fn(...list);
+  fn(3, [2, 1, 0], ...list);
+  fn(0, ...list, 4);
+});


### PR DESCRIPTION
This may not be the option with the best performance in ES5, but it is close. This fixes #37.

Note that I used a wrapper function, so that you can write functions in about the same way as in ES6, only with an extra `wrap(...)` around it. I chose for `__(list)` as it is visually the closest to `...list`. 
