### PR TITLE
Avoid dead code

### DIFF
--- a/tests/destructuring/destructuring.es6
+++ b/tests/destructuring/destructuring.es6
@@ -6,8 +6,8 @@ var data = {
 
 function fn() {
   var {a, b:{c:b}, arr:[, c]} = data;
-  return c;
+  return a.length + b.length + c;
 }
 
-assertEqual(fn(), 2);
+assertEqual(fn(), 6);
 test(fn);


### PR DESCRIPTION
The es5 version will be optimized in many engines to eliminate the 'a' and 'b' setting as dead code. It would be better to at least refer to them somehow, to prevent the DCE effects from washing out the es5 vs es6 difference. (eg in Firefox the es5 version will get DCE but the es6 version won't, which is a real difference but unlikely to be relevant for actual code.)

This PR is an incomplete change; I only updated the es6 version as an example. I don't know if that's the way you'd like to prevent DCE.
