### PR TITLE
`arrow-declare.es5` semantics were not equivalent to ES6

### DIFF
--- a/tests/arrow-declare/arrow-declare.es5
+++ b/tests/arrow-declare/arrow-declare.es5
@@ -1,8 +1,9 @@
 var obj = {
   value: 42,
   fn: function() {
+    var self = this;
     return function() {
-      return obj.value;
+      return self.value;
     };
   }
 };


### PR DESCRIPTION
The ES5 version captured the global `obj` variable, while the ES6 version created a closure and captured the `this` variable.
These are not semantically equivalent (eg. in case `obj` changes).

Fix: Changed the ES5 version to match the ES6 version by manually capturing `this`.
