### PR TITLE
add Closure Compiler JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "buble": "^0.15.1",
     "del": "^1.2.0",
     "esprima": "^1.2.5",
+    "google-closure-compiler-js": "^20170124.0.0",
     "gulp": "^3.9.0",
     "gulp-util": "^3.0.5",
     "handlebars": "^4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1731,6 +1731,14 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
+google-closure-compiler-js@^20170124.0.0:
+  version "20170124.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20170124.0.0.tgz#cd77291a19a4158eb41fb241688a5e523e250364"
+  dependencies:
+    gulp-util "^3.0.7"
+    minimist "^1.2.0"
+    webpack-core "^0.6.8"
+
 graceful-fs@^3.0.0:
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-3.0.11.tgz#7613c778a1afea62f25c630a086d7f3acbbdd818"
@@ -1749,7 +1757,7 @@ graceful-fs@~1.2.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-gulp-util@^3.0.0, gulp-util@^3.0.5:
+gulp-util@^3.0.0, gulp-util@^3.0.5, gulp-util@^3.0.7:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -3681,7 +3689,7 @@ webdriverio@^2.4.5:
     url "^0.10.1"
     wgxpath "^0.23.0"
 
-webpack-core@~0.6.9:
+webpack-core@^0.6.8, webpack-core@~0.6.9:
   version "0.6.9"
   resolved "https://registry.yarnpkg.com/webpack-core/-/webpack-core-0.6.9.tgz#fc571588c8558da77be9efb6debdc5a3b172bdc2"
   dependencies:


### PR DESCRIPTION
Resolves #33.

I work on the Closure Compiler's JS version at Google, and we'd like to add it to the benchmarks- it uses the JS version so no additional deps are needed.

I think this is all we need, the report seems to just include all unique types - there's no need to register the string "closure" somewhere else?